### PR TITLE
Standalone application UI helm chart initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# application-chart
+Open Cluster Management application lifecycle UI Helm chart

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,0 @@
-# application-chart
-Open Cluster Management application lifecycle Helm chart

--- a/stable/application-chart/Chart.yaml
+++ b/stable/application-chart/Chart.yaml
@@ -1,0 +1,14 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+apiVersion: v1
+appVersion: "1.0.0"
+description:  Helm chart for Open Cluster Management application UI
+name: application
+version: 1.0.0
+category: "Development"
+tillerVersion: ">=2.9.1"
+kubeVersion: ">=1.10.0"
+keywords:
+  - ui

--- a/stable/application-chart/templates/_helpers.tpl
+++ b/stable/application-chart/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "application.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "application.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "application.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/application-chart/templates/applicationconsole-deployment.yaml
+++ b/stable/application-chart/templates/applicationconsole-deployment.yaml
@@ -1,0 +1,149 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "application.fullname" . }}-mcmapplicationui
+  labels:
+    app: {{ template "application.name" . }}
+    chart: {{ template "application.chart" . }}
+    component: "mcmapplicationui"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "application.name" . }}
+    helm.sh/chart: {{ template "application.chart" . }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "application.name" . }}
+      component: "mcmapplicationui"
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "application.name" . }}
+        component: "mcmapplicationui"
+        release: {{ .Release.Name }}
+        chart: {{ template "application.chart" . }}
+        heritage: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "application.name" . }}
+        helm.sh/chart: {{ template "application.chart" . }}
+      annotations:
+        productName: "IBM Multicloud Manager - Server"
+        productID: "317a72a4f22645aaa1b7a07a83c60af5"
+        productVersion: "3.1.1"
+        seccomp.security.alpha.kubernetes.io/pod: docker/default
+    spec:
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                {{- range .Values.arch }}
+                - {{ . }}
+                {{- end }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - mcmapplicationui
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+      tolerations:
+        - key: dedicated
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: mcm-application-ui
+        image: "{{ .Values.mcmapplicationui.image.repository }}:{{ .Values.mcmapplicationui.image.tag }}"
+        imagePullPolicy: {{ .Values.mcmapplicationui.image.pullPolicy }}
+        resources:
+        {{- toYaml .Values.mcmapplicationui.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        env:
+        - name: ICP_STANDALONE
+          value: "{{ .Values.standalone }}"
+        - name: hcmUiApiUrl
+          value: https://{{ .Values.consoleName }}-consoleapi:4000/hcmuiapi
+        - name: searchApiUrl
+          value: https://search-search-api:4010/searchapi
+        - name: cfcRouterUrl
+          value: {{ .Values.cfcRouterUrl }}
+        - name: leftNav
+          value: {{ .Release.Name }}-nav
+        - name: PLATFORM_IDENTITY_PROVIDER_URL
+          value: {{ .Values.cfcRouterUrl }}/idprovider
+        - name: WLP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: WLP_CLIENT_ID
+              name: platform-oidc-credentials
+        - name: WLP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: WLP_CLIENT_SECRET
+              name: platform-oidc-credentials
+        ports:
+        - containerPort: 3001
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livenessProbe
+            port: 3001
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readinessProbe
+            port: 3001
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- if .Values.nodeSelector.enabled }}
+      nodeSelector:
+      {{- if .Values.nodeSelector.os }}
+        "beta.kubernetes.io/os" : {{ .Values.nodeSelector.os }}
+      {{- end }}
+      {{- if .Values.nodeSelector.customLabelSelector }}
+        {{ .Values.nodeSelector.customLabelSelector }} : {{ .Values.nodeSelector.customLabelValue}}
+      {{- end }}
+      {{- end }}

--- a/stable/application-chart/templates/applicationconsole-ingress.yaml
+++ b/stable/application-chart/templates/applicationconsole-ingress.yaml
@@ -1,0 +1,28 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    icp.management.ibm.com/auth-type: access-token
+    kubernetes.io/ingress.class: ibm-icp-management
+  name: {{ template "application.fullname" . }}-mcmapplicationui
+  labels:
+    app: {{ template "application.name" . }}
+    chart: {{ template "application.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "application.name" . }}
+    helm.sh/chart: {{ template "application.chart" . }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /multicloud/applications
+        backend:
+          serviceName: {{ template "application.fullname" . }}-mcmapplicationui
+          servicePort: 3001

--- a/stable/application-chart/templates/applicationconsole-service.yaml
+++ b/stable/application-chart/templates/applicationconsole-service.yaml
@@ -1,0 +1,29 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "application.fullname" . }}-mcmapplicationui
+  labels:
+    app: {{ template "application.name" . }}
+    component: "mcmapplicationui"
+    chart: {{ template "application.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "application.name" . }}
+    helm.sh/chart: {{ template "application.chart" . }}
+spec:
+  ports:
+    - port: 3001
+      targetPort: 3001
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "application.name" . }}
+    component: "mcmapplicationui"
+    release: {{ .Release.Name }}
+  

--- a/stable/application-chart/values.yaml
+++ b/stable/application-chart/values.yaml
@@ -1,0 +1,38 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2020 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+# Default values for console-chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+standalone: false
+pullSecret: null
+arch:
+- amd64
+- ppc64le
+- s390x
+
+replicas: 1
+
+nodeSelector:
+  enabled: false
+  os: ""
+  customLabelSelector: ""
+  customLabelValue: ""
+cfcRouterUrl: "https://icp-management-ingress:443"
+consoleName: "multicluster-hub-console"
+
+enabled: true
+mcmapplicationui:
+  image:
+    repository: quay.io/open-cluster-management/mcm-application-ui
+    tag: 3.5.0
+    pullPolicy: Always
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "400m"


### PR DESCRIPTION
For issue https://github.com/open-cluster-management/backlog/issues/470.

We need to work with the install team to fill in .Values.consoleName if this feature is enabled. This used to be set automatically when the application was together with the console chart but now we need to look it up.