### PR TITLE
Add imageTagPostfix to values.yaml

### DIFF
--- a/stable/application-chart/values.yaml
+++ b/stable/application-chart/values.yaml
@@ -8,6 +8,7 @@
 
 standalone: false
 pullSecret: null
+imageTagPostfix: ""
 arch:
 - amd64
 - ppc64le


### PR DESCRIPTION
.Values.imageTagPostfix is referenced in the deployment template but the values is missing from values.yaml

https://github.com/open-cluster-management/backlog/issues/724