### PR TITLE
remove productID annotation, not used

### DIFF
--- a/stable/application-chart/templates/applicationconsole-deployment.yaml
+++ b/stable/application-chart/templates/applicationconsole-deployment.yaml
@@ -36,6 +36,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ template "application.name" . }}
         helm.sh/chart: {{ template "application.chart" . }}
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: docker/default  
     spec:
       hostNetwork: false
       hostPID: false


### PR DESCRIPTION
removed 

annotations:
        productName: "IBM Multicloud Manager - Server"
        productID: "317a72a4f22645aaa1b7a07a83c60af5"
        productVersion: "3.1.1"
        seccomp.security.alpha.kubernetes.io/pod: docker/default