### PR TITLE
Add proxy support to app ui and console-api

### DIFF
--- a/stable/application-chart/Chart.yaml
+++ b/stable/application-chart/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 appVersion: "2.1.0"
 description:  Helm chart for Open Cluster Management application UI
 name: application-chart
-version: 2.1.0
+version: 2.4.0
 category: "Development"
 tillerVersion: ">=2.9.1"
 keywords:

--- a/stable/application-chart/templates/applicationconsole-deployment.yaml
+++ b/stable/application-chart/templates/applicationconsole-deployment.yaml
@@ -85,6 +85,14 @@ spec:
           value: https://console-api:4000/hcmuiapi
         - name: searchApiUrl
           value: https://search-search-api:4010/searchapi
+        {{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
         ports:
         - containerPort: 3001
           protocol: TCP

--- a/stable/application-chart/templates/hcmuiapi-deployment.yaml
+++ b/stable/application-chart/templates/hcmuiapi-deployment.yaml
@@ -107,6 +107,15 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
+        env:
+        {{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
         ports:
         - containerPort: 4000
           protocol: TCP


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/14073
https://github.com/open-cluster-management/backlog/issues/14015

- Added proxy info to app ui and console-api deployment resource if they are passed in the chart values
- Also update chart version to 2.4

Made sure the connection error doesn't appear anymore in a proxy env:
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/38960034/133670470-7afc0625-0a12-4c1f-a9d0-0e1cc811547d.png">
